### PR TITLE
Test Burrito webhook integration

### DIFF
--- a/burrito-config/terraform-repository.yaml
+++ b/burrito-config/terraform-repository.yaml
@@ -23,5 +23,6 @@ spec:
     namespace: burrito-system
   path: "."
   branch: "v2.0.0"
+  allowPrOnTags: true
   remediationStrategy:
     autoApply: false

--- a/main.tf
+++ b/main.tf
@@ -43,3 +43,8 @@ output "environment" {
 output "project_name" {
   value = var.project_name
 }
+
+# New output added for testing allowPrOnTags feature
+output "test_allowprontags" {
+  value = "Testing allowPrOnTags feature with tag v2.0.0"
+}


### PR DESCRIPTION
Testing the Burrito webhook integration with updated URL: https://angry-pets-follow.loca.lt/api/webhook. This PR will trigger webhook events to verify the complete pipeline functionality including plan generation and infrastructure synchronization.